### PR TITLE
Support idenfifiers, fixes #16

### DIFF
--- a/Sources/DynamicUI/Extensions/View.modifiers.swift
+++ b/Sources/DynamicUI/Extensions/View.modifiers.swift
@@ -123,19 +123,45 @@ extension View {
     func dynamicUIModifiers(_ modifiers: [String: AnyCodable]?) -> some View {
         self.modifier(DynamicUIModifier(modifiers: modifiers))
     }
+
+    /// Set Modifiers
+    ///
+    /// This function sets the modifiers for a DynamicUIView
+    ///
+    /// - Parameter modifiers: The modifiers to set
+    ///
+    /// - Returns: The modified view
+    func set(modifiers: DynamicUIComponent) -> some View {
+        var tempView = AnyView(self)
+
+        if let identifier = modifiers.identifier {
+            tempView = AnyView(tempView.id(identifier))
+        }
+
+        if let disabled = modifiers.disabled {
+            tempView = AnyView(tempView.disabled(disabled))
+        }
+
+        return tempView.dynamicUIModifiers(modifiers.modifiers)
+    }
 }
 
 #if DEBUG
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 #Preview {
-    Text("Test")
-        .dynamicUIModifiers([
-            "frame": .dictionary([
-                "width": .double(150),
-                "height": .double(100)
-            ]),
-            "foregroundStyle": .string("red"),
-            "disabled": .bool(true)
-        ])
+    let json = """
+        [
+            {
+               "type": "Text",
+               "title": "Title",
+               "disabled": true,
+               "modifiers": {
+                   "foregroundColor": "purple"
+               }
+            }
+        ]
+    """
+
+    DynamicUI(json: json, component: .constant(nil))
 }
 #endif

--- a/Sources/DynamicUI/Views/DynamicButton.swift
+++ b/Sources/DynamicUI/Views/DynamicButton.swift
@@ -64,7 +64,6 @@ struct DynamicButton: View {
             {
                "type": "Button",
                "title": "Title",
-               "disabled": true,
                "modifiers": {
                    "foregroundColor": "purple"
                }

--- a/Sources/DynamicUI/Views/DynamicButton.swift
+++ b/Sources/DynamicUI/Views/DynamicButton.swift
@@ -52,8 +52,7 @@ struct DynamicButton: View {
         }, label: {
             Text(component.title ?? "Button")
         })
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
     }
 }
 
@@ -65,6 +64,7 @@ struct DynamicButton: View {
             {
                "type": "Button",
                "title": "Title",
+               "disabled": true,
                "modifiers": {
                    "foregroundColor": "purple"
                }

--- a/Sources/DynamicUI/Views/DynamicDisclosureGroup.swift
+++ b/Sources/DynamicUI/Views/DynamicDisclosureGroup.swift
@@ -45,8 +45,7 @@ struct DynamicDisclosureGroup: View {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
 #else
         DynamicVStack(component)
 #endif

--- a/Sources/DynamicUI/Views/DynamicDivider.swift
+++ b/Sources/DynamicUI/Views/DynamicDivider.swift
@@ -39,8 +39,7 @@ struct DynamicDivider: View {
     /// Generated body for SwiftUI
     var body: some View {
         Divider()
-            .disabled(component.disabled ?? false)
-            .dynamicUIModifiers(component.modifiers)
+            .set(modifiers: component)
     }
 }
 

--- a/Sources/DynamicUI/Views/DynamicForm.swift
+++ b/Sources/DynamicUI/Views/DynamicForm.swift
@@ -44,8 +44,7 @@ struct DynamicForm: View {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
     }
 }
 

--- a/Sources/DynamicUI/Views/DynamicGauge.swift
+++ b/Sources/DynamicUI/Views/DynamicGauge.swift
@@ -52,8 +52,8 @@ struct DynamicGauge: View {
             Gauge(value: state) {
                 Text("\(component.title ?? "")")
             }
-            .disabled(component.disabled ?? false)
-            .dynamicUIModifiers(component.modifiers)
+            .set(modifiers: component)
+
         } else {
             EmptyView()
         }

--- a/Sources/DynamicUI/Views/DynamicGauge.swift
+++ b/Sources/DynamicUI/Views/DynamicGauge.swift
@@ -53,7 +53,6 @@ struct DynamicGauge: View {
                 Text("\(component.title ?? "")")
             }
             .set(modifiers: component)
-
         } else {
             EmptyView()
         }

--- a/Sources/DynamicUI/Views/DynamicGroup.swift
+++ b/Sources/DynamicUI/Views/DynamicGroup.swift
@@ -46,7 +46,6 @@ struct DynamicGroup: View {
             }
         }
         .set(modifiers: component)
-
 #else
         DynamicVStack(component)
 #endif

--- a/Sources/DynamicUI/Views/DynamicGroup.swift
+++ b/Sources/DynamicUI/Views/DynamicGroup.swift
@@ -45,12 +45,10 @@ struct DynamicGroup: View {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
+
 #else
         DynamicVStack(component)
-            .disabled(component.disabled ?? false)
-            .dynamicUIModifiers(component.modifiers)
 #endif
     }
 }

--- a/Sources/DynamicUI/Views/DynamicGroupBox.swift
+++ b/Sources/DynamicUI/Views/DynamicGroupBox.swift
@@ -46,7 +46,6 @@ struct DynamicGroupBox: View {
             }
         }
         .set(modifiers: component)
-
 #else
         DynamicVStack(component)
 #endif

--- a/Sources/DynamicUI/Views/DynamicGroupBox.swift
+++ b/Sources/DynamicUI/Views/DynamicGroupBox.swift
@@ -45,12 +45,10 @@ struct DynamicGroupBox: View {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
+
 #else
         DynamicVStack(component)
-            .disabled(component.disabled ?? false)
-            .dynamicUIModifiers(component.modifiers)
 #endif
     }
 }

--- a/Sources/DynamicUI/Views/DynamicHSplitView.swift
+++ b/Sources/DynamicUI/Views/DynamicHSplitView.swift
@@ -44,7 +44,7 @@ struct DynamicHSplitView: View {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
+        .set(modifiers: component)
 
 #else
         HStack {

--- a/Sources/DynamicUI/Views/DynamicHSplitView.swift
+++ b/Sources/DynamicUI/Views/DynamicHSplitView.swift
@@ -45,15 +45,15 @@ struct DynamicHSplitView: View {
             }
         }
         .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+
 #else
         HStack {
             if let children = component.children {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
+
 #endif
     }
 }

--- a/Sources/DynamicUI/Views/DynamicHSplitView.swift
+++ b/Sources/DynamicUI/Views/DynamicHSplitView.swift
@@ -45,7 +45,6 @@ struct DynamicHSplitView: View {
             }
         }
         .set(modifiers: component)
-
 #else
         HStack {
             if let children = component.children {
@@ -53,7 +52,6 @@ struct DynamicHSplitView: View {
             }
         }
         .set(modifiers: component)
-
 #endif
     }
 }

--- a/Sources/DynamicUI/Views/DynamicHStack.swift
+++ b/Sources/DynamicUI/Views/DynamicHStack.swift
@@ -44,8 +44,7 @@ struct DynamicHStack: View {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
     }
 }
 

--- a/Sources/DynamicUI/Views/DynamicImage.swift
+++ b/Sources/DynamicUI/Views/DynamicImage.swift
@@ -45,7 +45,6 @@ struct DynamicImage: View {
     var body: some View {
         Image(systemName: component.url ?? "")
             .accessibilityLabel(component.title ?? "")
-            .disabled(component.disabled ?? false)
-            .dynamicUIModifiers(component.modifiers)
+            .set(modifiers: component)
     }
 }

--- a/Sources/DynamicUI/Views/DynamicLabel.swift
+++ b/Sources/DynamicUI/Views/DynamicLabel.swift
@@ -45,7 +45,6 @@ struct DynamicLabel: View {
                 systemImage: systemImage
             )
             .set(modifiers: component)
-
         } else {
             DynamicText(component)
         }

--- a/Sources/DynamicUI/Views/DynamicLabel.swift
+++ b/Sources/DynamicUI/Views/DynamicLabel.swift
@@ -44,11 +44,10 @@ struct DynamicLabel: View {
                 component.title ?? "Label",
                 systemImage: systemImage
             )
-            .disabled(component.disabled ?? false)
-            .dynamicUIModifiers(component.modifiers)
+            .set(modifiers: component)
+
         } else {
             DynamicText(component)
-                .dynamicUIModifiers(component.modifiers)
         }
     }
 }

--- a/Sources/DynamicUI/Views/DynamicList.swift
+++ b/Sources/DynamicUI/Views/DynamicList.swift
@@ -44,8 +44,7 @@ struct DynamicList: View {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
     }
 }
 

--- a/Sources/DynamicUI/Views/DynamicNavigationView.swift
+++ b/Sources/DynamicUI/Views/DynamicNavigationView.swift
@@ -44,7 +44,6 @@ struct DynamicNavigationView: View {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
     }
 }

--- a/Sources/DynamicUI/Views/DynamicPicker.swift
+++ b/Sources/DynamicUI/Views/DynamicPicker.swift
@@ -55,7 +55,6 @@ struct DynamicPicker: View {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
     }
 }

--- a/Sources/DynamicUI/Views/DynamicProgressView.swift
+++ b/Sources/DynamicUI/Views/DynamicProgressView.swift
@@ -46,8 +46,7 @@ struct DynamicProgressView: View {
             value: component.defaultValue?.toDouble() ?? 0,
             total: component.maximumValue ?? 1.0
         )
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
     }
 }
 

--- a/Sources/DynamicUI/Views/DynamicScrollView.swift
+++ b/Sources/DynamicUI/Views/DynamicScrollView.swift
@@ -44,7 +44,6 @@ struct DynamicScrollView: View {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
     }
 }

--- a/Sources/DynamicUI/Views/DynamicSection.swift
+++ b/Sources/DynamicUI/Views/DynamicSection.swift
@@ -51,14 +51,14 @@ struct DynamicSection: View {
             Section(header: Text(title)) {
                 childrenView
             }
-            .disabled(component.disabled ?? false)
-            .dynamicUIModifiers(component.modifiers)
+            .set(modifiers: component)
+
         } else {
             Section {
                 childrenView
             }
-            .disabled(component.disabled ?? false)
-            .dynamicUIModifiers(component.modifiers)
+            .set(modifiers: component)
+
         }
     }
 }

--- a/Sources/DynamicUI/Views/DynamicSection.swift
+++ b/Sources/DynamicUI/Views/DynamicSection.swift
@@ -52,13 +52,11 @@ struct DynamicSection: View {
                 childrenView
             }
             .set(modifiers: component)
-
         } else {
             Section {
                 childrenView
             }
             .set(modifiers: component)
-
         }
     }
 }

--- a/Sources/DynamicUI/Views/DynamicSecureTextField.swift
+++ b/Sources/DynamicUI/Views/DynamicSecureTextField.swift
@@ -49,7 +49,6 @@ struct DynamicSecureField: View {
             "\(component.title ?? "")",
             text: $state
         )
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
     }
 }

--- a/Sources/DynamicUI/Views/DynamicSlider.swift
+++ b/Sources/DynamicUI/Views/DynamicSlider.swift
@@ -59,8 +59,8 @@ struct DynamicSlider: View {
         } maximumValueLabel: {
             Text("\(component.maximum ?? "")")
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
+
 #else
         EmptyView()
 #endif

--- a/Sources/DynamicUI/Views/DynamicSlider.swift
+++ b/Sources/DynamicUI/Views/DynamicSlider.swift
@@ -60,7 +60,6 @@ struct DynamicSlider: View {
             Text("\(component.maximum ?? "")")
         }
         .set(modifiers: component)
-
 #else
         EmptyView()
 #endif

--- a/Sources/DynamicUI/Views/DynamicSpacer.swift
+++ b/Sources/DynamicUI/Views/DynamicSpacer.swift
@@ -39,8 +39,7 @@ struct DynamicSpacer: View {
     /// Generated body for SwiftUI
     var body: some View {
         Spacer()
-            .disabled(component.disabled ?? false)
-            .dynamicUIModifiers(component.modifiers)
+            .set(modifiers: component)
     }
 }
 

--- a/Sources/DynamicUI/Views/DynamicTEMPLATE.swift
+++ b/Sources/DynamicUI/Views/DynamicTEMPLATE.swift
@@ -45,7 +45,6 @@ struct DynamicTEMPLATE: View {
     /// Generated body for SwiftUI
     var body: some View {
         EmptyView()
-            .disabled(component.disabled ?? false)
-            .dynamicUIModifiers(component.modifiers)
+            .set(modifiers: component)
     }
 }

--- a/Sources/DynamicUI/Views/DynamicText.swift
+++ b/Sources/DynamicUI/Views/DynamicText.swift
@@ -41,8 +41,7 @@ struct DynamicText: View {
     /// Generated body for SwiftUI
     var body: some View {
         Text(.init(component.title ?? ""))
-            .disabled(component.disabled ?? false)
-            .dynamicUIModifiers(component.modifiers)
+            .set(modifiers: component)
     }
 }
 

--- a/Sources/DynamicUI/Views/DynamicTextEditor.swift
+++ b/Sources/DynamicUI/Views/DynamicTextEditor.swift
@@ -53,7 +53,6 @@ struct DynamicTextEditor: View {
             dynamicUIEnvironment.component = newComponent
         }))
         .set(modifiers: component)
-
 #else
         DynamicTextField(component)
 #endif

--- a/Sources/DynamicUI/Views/DynamicTextEditor.swift
+++ b/Sources/DynamicUI/Views/DynamicTextEditor.swift
@@ -45,18 +45,17 @@ struct DynamicTextEditor: View {
 
     /// Generated body for SwiftUI
     var body: some View {
-#if os(iOS) && os(macOS)
+#if os(iOS) || os(macOS)
         TextEditor(text: $state.onChange({ _ in
             var newComponent = component
             newComponent.state = .string(state)
 
-            dynamicUIEnvironment.callback(newComponent)
+            dynamicUIEnvironment.component = newComponent
         }))
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
+
 #else
         DynamicTextField(component)
-            .dynamicUIModifiers(component.modifiers)
 #endif
     }
 }

--- a/Sources/DynamicUI/Views/DynamicTextField.swift
+++ b/Sources/DynamicUI/Views/DynamicTextField.swift
@@ -54,7 +54,6 @@ struct DynamicTextField: View {
                 dynamicUIEnvironment.component = newComponent
             })
         )
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
     }
 }

--- a/Sources/DynamicUI/Views/DynamicToggle.swift
+++ b/Sources/DynamicUI/Views/DynamicToggle.swift
@@ -57,8 +57,7 @@ struct DynamicToggle: View {
         })) {
             Text(title)
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
     }
 }
 

--- a/Sources/DynamicUI/Views/DynamicVSplitView.swift
+++ b/Sources/DynamicUI/Views/DynamicVSplitView.swift
@@ -45,8 +45,8 @@ struct DynamicVSplitView: View {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
+
 #else
         EmptyView()
 #endif

--- a/Sources/DynamicUI/Views/DynamicVSplitView.swift
+++ b/Sources/DynamicUI/Views/DynamicVSplitView.swift
@@ -46,7 +46,6 @@ struct DynamicVSplitView: View {
             }
         }
         .set(modifiers: component)
-
 #else
         EmptyView()
 #endif

--- a/Sources/DynamicUI/Views/DynamicVStack.swift
+++ b/Sources/DynamicUI/Views/DynamicVStack.swift
@@ -44,7 +44,6 @@ struct DynamicVStack: View {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
     }
 }

--- a/Sources/DynamicUI/Views/DynamicZStack.swift
+++ b/Sources/DynamicUI/Views/DynamicZStack.swift
@@ -44,7 +44,6 @@ struct DynamicZStack: View {
                 AnyView(dynamicUIEnvironment.buildView(for: children))
             }
         }
-        .disabled(component.disabled ?? false)
-        .dynamicUIModifiers(component.modifiers)
+        .set(modifiers: component)
     }
 }


### PR DESCRIPTION
## Pull Request Overview

This PR introduces identifier support for DynamicUI components by consolidating modifier application logic into a new `set(modifiers:)` method that handles identifiers, disabled state, and dynamic modifiers. It replaces the scattered `.disabled()` and `.dynamicUIModifiers()` calls across all view components with a unified approach.

- Consolidated modifier application into a single `set(modifiers:)` method
- Added identifier support through the new method
- Standardized modifier handling across all DynamicUI view components

### Reviewed Changes

Copilot reviewed 29 out of 29 changed files in this pull request and generated 2 comments.

| File | Description |
| ---- | ----------- |
| Sources/DynamicUI/Views/*.swift | Replaced individual `.disabled()` and `.dynamicUIModifiers()` calls with unified `.set(modifiers:)` method |
| Sources/DynamicUI/Extensions/View.modifiers.swift | Added new `set(modifiers:)` method that handles identifiers, disabled state, and applies dynamic modifiers |
